### PR TITLE
Add method to fetch cms base url from parent window

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,11 @@ Instructs the parent CMS window to navigate to a relative URL.
 ```javascript
 client.navigateCms('/some/other/page')
 ```
+
+## `client.getCmsBaseUrl()`
+
+Returns the base url of the parent CMS window.
+
+```javascript
+client.getCmsBaseUrl()
+```

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ let cmsRequests = []
 const client = {
   cmsRequest,
   navigateCms,
+  getCmsBaseUrl,
   getToken() {
     return new Promise((resolve, reject) => {
       if (accessToken) {
@@ -78,6 +79,10 @@ function getRegion(cmsRoot) {
   if (cmsRoot.indexOf("https://qa.cms.doubledutch.me") === 0) return 'qa'
   if (cmsRoot.indexOf("http://cms.local:") === 0 || cmsRoot.indexOf("http://localhost:") === 0) return 'local'
   return 'none'
+}
+
+function getCmsBaseUrl() {
+  return cmsRoot;
 }
 
 function cmsRequest(method, relativeUrl, bodyJSON) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,6 +35,12 @@ test('client can navigate to relative url', async () => {
   expect(global._window.location).toEqual('/some/place')
 })
 
+test('client will return correct cms base url', async () => {
+  const cmsBaseUrl = client.getCmsBaseUrl()
+
+  expect(cmsBaseUrl).toEqual('https://cms.doubledutch.me')
+})
+
 test('CMS API request resolves to response', async () => {
   global._xmlHttpRequestSpy.openParams = [getConfigParams]
   global._xmlHttpRequestSpy.responseBodies = [{ some: 'config' }]


### PR DESCRIPTION
This change helps to provide links to other pages on the CMS when embedded in an iframe with another hostname.