### PR TITLE
add content-type header for all CMS calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,7 @@ function cmsRequest(method, relativeUrl, bodyJSON) {
       const request = new xmlHttpRequest()
       request.open(method, url, true)
       request.setRequestHeader('Authorization', `Bearer ${accessToken}`)
+      request.setRequestHeader('Content-Type', 'application/json')
       request.onload = function() {
         if (this.status == 401) {
           accessToken = null
@@ -150,7 +151,6 @@ function cmsRequest(method, relativeUrl, bodyJSON) {
       }
       if (bodyJSON) {
         const body = JSON.stringify(bodyJSON)
-        request.setRequestHeader('Content-Type', 'application/json')
         request.send(body)
       } else {
         request.send()


### PR DESCRIPTION
New CMS(dotnet core 2.2) has an issue for a GET call without Content-type header is thrown away with http status code `415 Unsupported Media Type`.
Reference: https://github.com/aspnet/AspNetCore/issues/4396